### PR TITLE
Add input for python PATH

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -7,6 +7,7 @@ const ipcRenderer = require("electron").ipcRenderer;
 const jsesc = require('jsesc');
 
 var instapyPath = "";
+var pythonPath = "";
 var pyshell;
 var running = false;
 var data;
@@ -19,6 +20,11 @@ var checkPath = settings.get("instapyPath");
 if (checkPath) {
   instapyPath = checkPath;
   displayPath(checkPath);
+}
+var checkPythonPath = settings.get("pythonPath");
+if (checkPythonPath) {
+  pythonPath = checkPythonPath;
+  displayPythonPath(checkPythonPath)
 }
 
 var params = {
@@ -324,8 +330,7 @@ var app = {
   },
   unfollowUsers: function(on) {
     var content = ``;
-    if (on) {
-		if (data.unfollowMethod == "InstaPy") {
+    if (on) { if (data.unfollowMethod == "InstaPy") {
 			var instaPyMode = `'${data.unfollowMethod}'`;
 			var onlyInstaPyMode = "True";
     		content = `\nsession.unfollow_users(amount=${data.unfollowAmount}, onlyInstapyFollowed=${onlyInstaPyMode}, onlyInstapyMethod:${instaPyMode}, sleep_delay=${data.unfollowDelay})`;
@@ -391,8 +396,9 @@ var app = {
 var shell = {
   initProcess: function() {
     pyshell = new PythonShell("quickstart.py", {
+      pythonPath: (pythonPath.length > 2) ? pythonPath : undefined,
       pythonOptions: ["-u"],
-      cwd: instapyPath
+      scriptPath: instapyPath + '/'
     });
     running = !pyshell.terminated;
 

--- a/assets/js/view.js
+++ b/assets/js/view.js
@@ -83,6 +83,14 @@ function displayPath(path) {
   $("#displayPath").val(path);
 }
 
+// on input changepython path
+$('#pythonPath').on("change", function(event) {
+  settings.set("pythonPath", event.target.value); 
+});
+function displayPythonPath(path) {
+  $("#pythonPath").val(path);
+}
+
 function fileCheck() {
   fileExists(instapyPath.concat("/assets/chromedriver")).then(exists => {
     if (exists) {

--- a/index.html
+++ b/index.html
@@ -81,6 +81,13 @@
                         <input id="displayPath" type="text" value="Select InstaPy root directory" style="pointer-events: none">  
                         <input id="path" type="file" style="display: none" webkitdirectory />
                     </div> 
+                    <div class="ui left action input" style="margin-top:.8em; color: #222;">
+			<div class="ui button" style="background-color:#F6CC11; padding:.4em; padding-left:.8em; pointer-events: none;">
+			    <span style="font-size:.9em; margin:0;">Python PATH, </span>
+ 			    <span style="font-size:.7em; margin:0;">Leave empty for default</span>
+			</div>
+                        <input id="pythonPath" type="text" value="">  
+                    </div> 
                     <!-- SETTINGS  -->
                     <div class="ui horizontal secondary segments">
                         <div class="ui secondary segment">


### PR DESCRIPTION
Add ability to choose which python to run, via input beneath instapy path.

Might fix  #38, #27 

When trying to run the gui on Ubuntu (maybe other platforms as well).
The script would hang as shown in those 2 issues. no errors shown except in the console.
It was because the script couldn't find the path to python.
